### PR TITLE
switch `source`to `.`

### DIFF
--- a/src/container/nvm.ts
+++ b/src/container/nvm.ts
@@ -37,7 +37,7 @@ export class NVM {
   }
 
   nvmCommandBuilder = (command: string): string =>
-    `source ~/.nvm/nvm.sh && ${command}`;
+    `. ~/.nvm/nvm.sh && ${command}`;
 
   async isNvmInstalled(): Promise<boolean> {
     const command = this.nvmCommandBuilder('nvm');


### PR DESCRIPTION
source is for bash only.
In my case, sh was use by default and causing error :
```
Command failed: source ~/.nvm/nvm.sh && nvm current /bin/sh: 1: source: not found
```